### PR TITLE
Ignore generated __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+src/__pycache__/
+src/gpodder/__pycache__/
+src/gpodder/plugins/__pycache__/


### PR DESCRIPTION
Adding a .gitignore file, so it's easier to track changes when running gPodder directly from a git clone
