### PR TITLE
Fix for Bug 1939 (gpodder-migrate2cuatro fails)

### DIFF
--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -106,6 +106,7 @@ PodcastColumns = (
     'section',
     'payment_url',
     'download_strategy',
+    'sync_to_mp3_player',
 )
 
 


### PR DESCRIPTION
Hello Thomas. I added the **sync_to_mp3_player** attribute to the **Podcast** object in order to fix [bug 1939](http://bugs.gpodder.org/show_bug.cgi?id=1939). gpodder-migrate2cuatro script now works.
