### PR TITLE
Adding publish date to file name

### DIFF
--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -42,6 +42,7 @@ import shutil
 import os.path
 import os
 import time
+import datetime
 import collections
 
 import mimetypes
@@ -809,10 +810,12 @@ class DownloadTask(object):
             self.filename = self.__episode.local_filename(create=False)
             self.tempname = os.path.join(os.path.dirname(self.filename),
                                          os.path.basename(self.tempname))
-            shutil.move(self.tempname, self.filename)
+            head, tail = os.path.split(self.filename)    
+            newfilename = os.path.join(head, datetime.datetime.fromtimestamp(self.__episode.published).strftime("%Y%m%d_") + tail)
+            shutil.move(self.tempname, newfilename)
 
             # Model- and database-related updates after a download has finished
-            self.__episode.on_downloaded(self.filename)
+            self.__episode.on_downloaded(newfilename)
         except DownloadCancelledException:
             logger.info('Download has been cancelled/paused: %s', self)
             if self.status == DownloadTask.CANCELLED:


### PR DESCRIPTION
Hi,

I don't know if this is an item you want to merge or not, but one problem I routinely run into with gpodder is that if the podcast doesn't correctly name a file with a date or number at the front, it is impossible to know what order the podcasts should be played in.  To rectify this issue, I've added the the publish date to the front of the podcast file name.  Adding pull request if this is something people might use.