### PR TITLE
Fix YouTube videos download

### DIFF
--- a/src/gpodder/plugins/youtube.py
+++ b/src/gpodder/plugins/youtube.py
@@ -108,7 +108,7 @@ def youtube_resolve_download_url(episode, config):
         return None
 
     page = None
-    url = 'http://www.youtube.com/get_video_info?&el=detailpage&video_id=' + vid
+    url = 'https://www.youtube.com/get_video_info?&el=detailpage&video_id=' + vid
 
     while page is None:
         req = util.http_request(url, method='GET')

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -694,7 +694,10 @@ def urlopen(url, headers=None, data=None, timeout=None):
 
 def http_request(url, method='HEAD'):
     (scheme, netloc, path, parms, qry, fragid) = urllib.parse.urlparse(url)
-    conn = http.client.HTTPConnection(netloc)
+    if scheme == 'https':
+        conn = http.client.HTTPSConnection(netloc)
+    else:
+        conn = http.client.HTTPConnection(netloc)
     start = len(scheme) + len('://') + len(netloc)
     conn.request(method, url[start:])
     return conn.getresponse()


### PR DESCRIPTION
YouTube has disabled HTTP a few weeks ago, making videos download failing.
A fix has been done mainstream: https://github.com/gpodder/gpodder/pull/626
This is a simple backport of it. I've tested it by applying the patch on my SailfishOS device, it fixes the issue.