### PR TITLE
Soundcloud optimize

### DIFF
--- a/src/gpodder/__init__.py
+++ b/src/gpodder/__init__.py
@@ -50,10 +50,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # This metadata block gets parsed by setup.py - use single quotes only
 __tagline__ = 'Media and podcast aggregator'
 __author__ = 'Thomas Perl <thp@gpodder.org>'
-__version__ = '4.6.0'
-__date__ = '2015-05-24'
-__relname__ = 'Industrial'
-__copyright__ = '© 2005-2016 Thomas Perl and the gPodder Team'
+__version__ = '4.9.0'
+__date__ = '2019-12-10'
+__relname__ = 'Tal'
+__copyright__ = '© 2005-2019 Thomas Perl and the gPodder Team'
 __license__ = 'ISC / GPLv3 or later'
 __url__ = 'http://gpodder.org/'
 

--- a/src/gpodder/plugins/soundcloud.py
+++ b/src/gpodder/plugins/soundcloud.py
@@ -123,7 +123,6 @@ class SoundcloudUser(object):
         The generator will give you a dictionary for every
         track it can find for its user."""
         global CONSUMER_KEY
-        read_from_cache = 0
 
         json_url = ('https://api.soundcloud.com/users/%(user)s/%(feed)s.'
                     'json?consumer_key=%'
@@ -137,13 +136,14 @@ class SoundcloudUser(object):
         json_tracks = json.loads(util.urlopen(json_url).read().decode('utf-8'))
         tracks = [track for track in json_tracks if track['streamable'] or track['downloadable']]
 
-        existing_guids = { episode.guid:
-                            { "filesize": episode.file_size,
-                              "filetype": episode.mime_type,
-                            } for episode in channel.episodes
-                         }
+        self.cache['episodes'] = { episode.guid:
+                                   { "filesize": episode.file_size,
+                                     "filetype": episode.mime_type,
+                                   } for episode in channel.episodes
+                                 }
 
-        logger.debug('%d Episodes in database for Soundcloud:%s', len(existing_guids), self.username)
+        read_from_cache = 0
+        logger.debug('%d Episodes in database for Soundcloud:%s', len(self.cache['episodes']), self.username)
 
         for track in tracks:
             # Prefer stream URL (MP3), fallback to download URL
@@ -156,11 +156,11 @@ class SoundcloudUser(object):
 
             track_guid = track.get('permalink', track.get('id'))
 
-            if track_guid not in existing_guids:
+            if track_guid not in self.cache['episodes']:
                 filesize, filetype, filename = get_metadata(url)
             else:
-                filesize = existing_guids[track_guid]['filesize']
-                filetype = existing_guids[track_guid]['filetype']
+                filesize = self.cache['episodes'][track_guid]['filesize']
+                filetype = self.cache['episodes'][track_guid]['filetype']
                 read_from_cache += 1
 
             yield {
@@ -175,7 +175,7 @@ class SoundcloudUser(object):
                 'total_time': int(track.get('duration') / 1000),
             }
 
-        logger.debug('Read %d episodes from %d cached episodes', read_from_cache, len(existing_guids))
+        logger.debug('Read %d episodes from %d cached episodes', read_from_cache, len(self.cache['episodes']))
 
 
 class SoundcloudFeed(object):

--- a/src/gpodder/plugins/soundcloud.py
+++ b/src/gpodder/plugins/soundcloud.py
@@ -91,14 +91,19 @@ def get_metadata(url):
 class SoundcloudUser(object):
     def __init__(self, username):
         self.username = username
+        self.cache = {}
 
     def get_user_info(self):
         global CONSUMER_KEY
         key = ':'.join((self.username, 'user_info'))
 
+        if key in self.cache:
+            return self.cache[key]
+
         json_url = 'https://api.soundcloud.com/users/%s.json?consumer_key=%s' % (self.username, CONSUMER_KEY)
         logger.debug('get_user_info url: %s', json_url)
         user_info = json.loads(util.urlopen(json_url).read().decode('utf-8'))
+        self.cache[key] = user_info
 
         return user_info
 

--- a/src/gpodder/plugins/soundcloud.py
+++ b/src/gpodder/plugins/soundcloud.py
@@ -167,6 +167,7 @@ class SoundcloudUser(object):
                 'mime_type': filetype,
                 'guid': track_guid,
                 'published': soundcloud_parsedate(track.get('created_at', None)),
+                'total_time': int(track.get('duration') / 1000)
             }
 
 

--- a/src/gpodder/plugins/soundcloud.py
+++ b/src/gpodder/plugins/soundcloud.py
@@ -97,15 +97,13 @@ class SoundcloudUser(object):
         global CONSUMER_KEY
         key = ':'.join((self.username, 'user_info'))
 
-        if key in self.cache:
-            return self.cache[key]
+        if key not in self.cache:
+            json_url = 'https://api.soundcloud.com/users/%s.json?consumer_key=%s' % (self.username, CONSUMER_KEY)
+            logger.debug('get_user_info url: %s', json_url)
+            user_info = json.loads(util.urlopen(json_url).read().decode('utf-8'))
+            self.cache[key] = user_info
 
-        json_url = 'https://api.soundcloud.com/users/%s.json?consumer_key=%s' % (self.username, CONSUMER_KEY)
-        logger.debug('get_user_info url: %s', json_url)
-        user_info = json.loads(util.urlopen(json_url).read().decode('utf-8'))
-        self.cache[key] = user_info
-
-        return user_info
+        return self.cache[key]
 
     def get_coverart(self):
         user_info = self.get_user_info()
@@ -167,7 +165,7 @@ class SoundcloudUser(object):
                 'mime_type': filetype,
                 'guid': track_guid,
                 'published': soundcloud_parsedate(track.get('created_at', None)),
-                'total_time': int(track.get('duration') / 1000)
+                'total_time': int(track.get('duration') / 1000),
             }
 
 

--- a/src/gpodder/plugins/soundcloud.py
+++ b/src/gpodder/plugins/soundcloud.py
@@ -31,7 +31,7 @@ import urllib.parse
 import urllib.request
 
 import gpodder
-from gpodder import model, util, registry, directory, core
+from gpodder import model, util, registry, directory
 
 # _ = qsTr
 


### PR DESCRIPTION
This optimizes performance of search for new episodes by utilizing a runtime cache and the episodes object in the podcast.

Adding a Soundcloud API based podcast still will take long depending on the number of tracks it contains since headers are retrieved for each track.