### PR TITLE
Feature/cap max downloaded

### DIFF
--- a/bin/gpo
+++ b/bin/gpo
@@ -1136,7 +1136,7 @@ class gPodderCli(object):
         out(*args)
 
     def _checkargs(self, func, command_line):
-        args, varargs, keywords, defaults = inspect.getargspec(func)
+        args, varargs, keywords, defaults, _, _, _ = inspect.getfullargspec(func)
         args.pop(0)  # Remove "self" from args
         defaults = defaults or ()
         minarg, maxarg = len(args)-len(defaults), len(args)

--- a/bin/gpo
+++ b/bin/gpo
@@ -898,15 +898,24 @@ class gPodderCli(object):
         Use {pending} to see a list of episodes that would be downloaded.
         """
         count = 0
+        max = self._config.get_field('limit.downloads.podcast_max_new')
         for podcast in self._get_podcasts(url):
             podcast_printed = False
+            current = 0
             for episode in podcast.episodes:
+                if episode.state == gpodder.STATE_DOWNLOADED:
+                    current += 1
+                    if current >= max:
+                        break
                 if self._is_episode_new(episode):
                     if not podcast_printed:
                         out(inblue(podcast.title))
                         podcast_printed = True
                     self._download_episode(episode)
                     count += 1
+                    current += 1
+                    if current >= max:
+                        break
 
         self._download_summary(count)
         return True

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -43,6 +43,7 @@ defaults = {
         'downloads': {
             'enabled': True,
             'concurrent': 1,
+            'podcast_max_new': 200,       # per podcast download limit same as episode limit
         },
         'episodes': 200,  # max episodes per feed
     },


### PR DESCRIPTION
If you want this, it does the following:

- Doesn't affect existing operation
- If the config `limit.downloads.podcast_max_new` is set to `5` (for example), then 5 episodes are downloaded in the `download` command



