### PR TITLE
Feature/35 support chonological podcasts take2

### DIFF
--- a/bin/gpo
+++ b/bin/gpo
@@ -488,12 +488,14 @@ class gPodderCli(object):
 
             title, url, status = podcast.title, podcast.url, \
                 feed_update_status_msg(podcast)
+            strategy = 'episodic (newest first)' if podcast.download_strategy != podcast.STRATEGY_CHRONO else 'serial (oldest first)'
             episodes = self._episodesList(podcast)
             episodes = '\n      '.join(episodes)
             self._pager("""
     Title: %(title)s
     URL: %(url)s
     Feed update is %(status)s
+    Feed Order: %(strategy)s
 
     Episodes:
       %(episodes)s
@@ -564,6 +566,7 @@ class gPodderCli(object):
         return True
 
     def _format_podcast(self, podcast):
+        strategy = '' if podcast.download_strategy != podcast.STRATEGY_CHRONO else '(serial)'
         if not podcast.pause_subscription:
             return ' '.join(('#', ingreen(podcast.title)))
 

--- a/src/gpodder/plugins/podcast.py
+++ b/src/gpodder/plugins/podcast.py
@@ -86,6 +86,9 @@ class PodcastParserFeed(object):
     def get_link(self):
         return self.parsed.get('link', '')
 
+    def get_type(self):
+        return self.parsed.get('type', 'episodic')
+
     def get_description(self):
         return self.parsed.get('description', '')
 

--- a/src/gpodder/storage.py
+++ b/src/gpodder/storage.py
@@ -18,7 +18,7 @@
 
 import minidb
 
-from gpodder import model
+from gpodder import model, STATE_DOWNLOADED, STATE_NORMAL
 from gpodder import util
 
 import json
@@ -102,7 +102,10 @@ class Database:
         return model.PodcastChannel.load(self.db)(*args)
 
     def load_episodes(self, podcast, *args):
-        return model.PodcastEpisode.load(self.db, podcast_id=podcast.id)(*args)
+        # Don't load deleted podcasts
+        ifpodcast = (model.PodcastEpisode.c.podcast_id==podcast.id)
+        ifdown = ((model.PodcastEpisode.c.state==STATE_NORMAL) | (model.PodcastEpisode.c.state==STATE_DOWNLOADED))
+        return model.PodcastEpisode.load(self.db, ifpodcast & ifdown)(*args)
 
     def commit(self):
         self.db.commit()


### PR DESCRIPTION
Rework of gpodder/gpodder-core/pull/39 and fixes #35 

Requires gpodder/podcastparser/pull/22 which adds support for tag [itunes:type](https://help.apple.com/itc/podcasts_connect/#/itcb54353390) 
