### PR TITLE
Modifications that allow dynamic loading of cover art.

### DIFF
--- a/src/gpodder/coverart.py
+++ b/src/gpodder/coverart.py
@@ -46,12 +46,9 @@ class CoverDownloader(object):
 
     def get_cover(self, podcast, download=False, episode=None):
         if episode:
-            if podcast.download_episode_art == True:
-                # Get episode art.
-                filename = episode.art_file
-                cover_url = episode.episode_art_url
-            else:
-                cover_url = None
+            # Get episode art.
+            filename = episode.art_file
+            cover_url = episode.episode_art_url
 
         else:
             # Get podcast cover.
@@ -67,7 +64,7 @@ class CoverDownloader(object):
         # Return already existing files
         for extension in self.EXTENSIONS:
             if os.path.exists(filename + extension):
-                return filename + extension
+                return 'file://' + filename + extension
 
         # If allowed to download files, do so here
         if download:
@@ -104,8 +101,10 @@ class CoverDownloader(object):
                     with open(temp_filename, 'wb') as fp:
                         fp.write(data)
 
-                return filename + extension
+                return 'file://' + filename + extension
             except Exception as e:
                 logger.warn('Cannot save cover art', exc_info=True)
+        else:
+            return cover_url
 
         return None

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -271,6 +271,13 @@ class PodcastEpisode(EpisodeModelFields, PodcastModelMixin):
         if filename is not None:
             util.delete_file(filename)
 
+        art_filename = self.art_file
+        if art_filename is not None:
+            for extension in self.podcast.model.core.cover_downloader.EXTENSIONS:
+                if os.path.exists(art_filename + extension):
+                    art_filename = art_filename + extension
+                    util.delete_file(art_filename)
+
         self.state = gpodder.STATE_DELETED
         self.is_new = False
         self.save()
@@ -757,10 +764,6 @@ class PodcastChannel(PodcastModelFields, PodcastModelMixin):
 
         # Add new episodes to episodes
         self.episodes.extend(new_episodes)
-
-        # Verify that all episode art is up-to-date
-        for episode in self.episodes:
-            self.model.core.cover_downloader.get_cover(self, download=True, episode=episode)
 
         # Sort episodes by pubdate, descending
         self.episodes.sort(key=lambda e: e.published, reverse=True)


### PR DESCRIPTION
Episode art will only be downloaded when the episode is downloaded too and will be deleted when the episode is deleted.

**Note: get_cover() now returns full URIs instead of a path only**