### PR TITLE
Opml section export and import

### DIFF
--- a/src/gpodder/opml.py
+++ b/src/gpodder/opml.py
@@ -70,10 +70,16 @@ class Importer(object):
             else:
                 doc = xml.dom.minidom.parseString(util.urlopen(url).read())
 
+            section = None
             for outline in doc.getElementsByTagName('outline'):
                 # Make sure we are dealing with a valid link type (ignore case)
                 otl_type = outline.getAttribute('type')
                 if otl_type is None or otl_type.lower() not in self.VALID_TYPES:
+                    otl_title = outline.getAttribute('title')
+                    otl_text = outline.getAttribute('text')
+                    #gPodder sections will have name == text, if OPML accepts it type=section
+                    if otl_title is not None and otl_title == otl_text:
+                        section = otl_title
                     continue
 
                 if outline.getAttribute('xmlUrl') or outline.getAttribute('url'):
@@ -86,6 +92,7 @@ class Importer(object):
                                'description': (outline.getAttribute('text') or
                                                outline.getAttribute('xmlUrl') or
                                                outline.getAttribute('url')),
+                               'section': section or 'audio'
                                }
 
                     if channel['description'] == channel['title']:

--- a/src/gpodder/opml.py
+++ b/src/gpodder/opml.py
@@ -141,6 +141,15 @@ class Exporter(object):
         outline.setAttribute('type', self.FEED_TYPE)
         return outline
 
+    def create_section(self, doc, name):
+        """
+        Creates an empty OPML ouline element used to divide sections.
+        """
+        section = doc.createElement('outline')
+        section.setAttribute('title', name)
+        section.setAttribute('text', name)
+        return section
+
     def write(self, channels):
         """
         Creates a XML document containing metadata for each
@@ -165,8 +174,16 @@ class Exporter(object):
         opml.appendChild(head)
 
         body = doc.createElement('body')
+        sections = {}
         for channel in channels:
-            body.appendChild(self.create_outline(doc, channel))
+            if channel.section not in sections.keys():
+                sections[channel.section] = self.create_section(doc, channel.section)
+
+            sections[channel.section].appendChild(self.create_outline(doc, channel))
+
+        for section in sections.values():
+            body.appendChild(section)
+
         opml.appendChild(body)
 
         if self.filename is None:


### PR DESCRIPTION
This adds support for sections in the exported OPML file as well as passing the section back to the calling function on import.

For gpodder-sailfish further modifications need to be made in main.py to import_opml() and subscribe() for this to work.

As things stand import_opml just calls subscribe() with the RSS feed without any of the other data from the OPML file.