### PR TITLE
Disable the gpodder.net plugin

### DIFF
--- a/src/gpodder/core.py
+++ b/src/gpodder/core.py
@@ -96,7 +96,7 @@ class Core(object):
             'gpodder.plugins.podverse',
 
             # Directory plugins
-            'gpodder.plugins.gpoddernet',
+            #'gpodder.plugins.gpoddernet',
 
             # Fallback handlers (catch-all)
             'gpodder.plugins.podcast',


### PR DESCRIPTION
gpodder.net does not seem to be working and our attempts to reach out to the maintainers have failed.

The code itself is left, thus if someone sets up their own version of gpodder.net if it's private they can re-enable it for themselves and if it is public we can re-enable with updated hostnames.