### PR TITLE
Replace asserts with Exceptions

### DIFF
--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -106,9 +106,11 @@ class ContentRange(object):
     """
 
     def __init__(self, start, stop, length):
-        assert start >= 0, "Bad start: %r" % start
-        assert stop is None or (stop >= 0 and stop >= start), (
-            "Bad stop: %r" % stop)
+        if start < 0:
+            raise Exception("Bad start: %r" % start)
+        if not all(stop is None or (stop >= 0 and stop >= start)):
+            raise Exception("Bad stop: %r" % stop)
+
         self.start = start
         self.stop = stop
         self.length = length
@@ -563,7 +565,9 @@ class DownloadTask(object):
             util.delete_file(self.tempname)
 
     def __init__(self, episode):
-        assert episode.download_task is None
+        if episode.download_task is not None:
+            raise Exception('Download already in progress.')
+
         self.__status = DownloadTask.INIT
         self.__status_changed = True
         self.__episode = episode

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -49,6 +49,8 @@ import minidb
 class NoHandlerForURL(Exception):
     pass
 
+class DuplicatePodcastException(Exception):
+    pass
 
 def fetch_channel(channel, config):
     max_episodes = config.limit.episodes
@@ -807,7 +809,9 @@ class PodcastChannel(PodcastModelFields, PodcastModelMixin):
         self.model._append_podcast(self)
 
     def get_statistics(self):
-        assert self.id
+        # The following was an assert, it is not clear to me how this can ever happen.
+        if not self.id:
+            raise Exception('get_statistics() - No podcast ID defined.')
 
         total = len(self.episodes)
 
@@ -983,7 +987,9 @@ class Model(object):
         return self.podcasts
 
     def load_podcast(self, url, create=True, authentication_tokens=None):
-        assert all(url != podcast.url for podcast in self.get_podcasts())
+        if not all(url != podcast.url for podcast in self.get_podcasts()):
+            raise DuplicatePodcastException
+
         return self.PodcastClass.load_(self, url, create, authentication_tokens)
 
     def get_prefixes(self):

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -715,7 +715,8 @@ def sanitize_filename(filename, max_length=0, use_ascii=False):
     If use_ascii is True, don't encode in the native language,
     but use only characters from the ASCII character set.
     """
-    assert isinstance(filename, str)
+    if not isinstance(filename, str):
+        rasie Exception('filename is not a string')
 
     if max_length > 0 and len(filename) > max_length:
         logger.info('Limiting file/folder name "%s" to %d characters.', filename, max_length)


### PR DESCRIPTION
asserts are not meant for runtime checks and can be ignored if python runs in an optimized mode (https://medium.com/@alairjunior/assertions-are-not-exceptions-3f5540b4a9ea).

When I was 100% sure that the Exception would be something I want to show in UI I created a special exception like `DuplicatePodcastException` otherwise just a plain `Exception`.