### PR TITLE
Itunes fixes

### DIFF
--- a/src/gpodder/plugins/itunes.py
+++ b/src/gpodder/plugins/itunes.py
@@ -97,7 +97,7 @@ class ApplePodcastsSearchProvider(directory.Provider):
 
             if json_data['resultCount'] > 0:
                 for entry in json_data['results']:
-                    if entry.get('feedUrl') is None:
+                    if 'feedUrl' not in entry:
                         continue
 
                     title = entry['collectionName']

--- a/src/gpodder/plugins/itunes.py
+++ b/src/gpodder/plugins/itunes.py
@@ -95,29 +95,17 @@ class ApplePodcastsSearchProvider(directory.Provider):
             )
             json_data = util.read_json(json_url)
 
-            if json_data['resultCount'] > 0:
-                for entry in json_data['results']:
-                    if 'feedUrl' not in entry:
-                        continue
+            if json_data['resultCount'] <= 0:
+                return
+                
+            for entry in json_data['results']:
+                if 'feedUrl' not in entry:
+                    continue
 
-                    title = entry['collectionName']
-                    url = entry['feedUrl']
-                    image = entry['artworkUrl100']
+                title = entry['collectionName']
+                url = entry['feedUrl']
+                image = entry['artworkUrl100']
 
-                    yield directory.DirectoryEntry(title, url, image)
-                    returned_res += 1
+                yield directory.DirectoryEntry(title, url, image)
 
-                offset += json_data['resultCount']
-            else:
-            # Unlike the podverse stop condition where we detect a resultCount
-            # smaller than the page size for apple we can only stop when 0
-            # results are returned because the API seems to consistently
-            # return more than the page size and does this in an inconsistent
-            # fasion, most often returning 210 results but based on my
-            # observartion any number between page size and page size + 10 is
-            # possible.
-            #
-            # With an API that does not obey its own rules the only valid stop
-            # condition is no results.
-
-                break
+            offset += json_data['resultCount']

--- a/src/gpodder/plugins/itunes.py
+++ b/src/gpodder/plugins/itunes.py
@@ -39,26 +39,26 @@ def itunes_feed_handler(channel, max_episodes, config):
 
     logger.debug('Detected iTunes feed.')
 
-    itunes_lookup_url = 'https://itunes.apple.com/lookup?entity=podcast&id=' + m.group('podcast_id')
+    itunes_lookup_url = f'https://itunes.apple.com/lookup?entity=podcast&id={m.group("podcast_id")}'
     try:
         json_data = util.read_json(itunes_lookup_url)
 
         if len(json_data['results']) != 1:
-            raise ITunesFeedException('Unsupported number of results: ' + str(len(json_data['results'])))
+            raise ITunesFeedException(f'Unsupported number of results: {str(len(json_data["results"]))}')
 
         feed_url = util.normalize_feed_url(json_data['results'][0]['feedUrl'])
 
         if not feed_url:
-            raise ITunesFeedException('Could not resolve real feed URL from iTunes feed.\nDetected URL: ' + json_data['results'][0]['feedUrl'])
+            raise ITunesFeedException(f'Could not resolve real feed URL from iTunes feed.\nDetected URL: {json_data["results"][0]["feedUrl"]}')
 
-        logger.info('Resolved iTunes feed URL: {} -> {}'.format(channel.url, feed_url))
+        logger.info(f'Resolved iTunes feed URL: {channel.url} -> {feed_url}')
         channel.url = feed_url
 
         # Delegate further processing of the feed to the normal podcast parser
         # by returning None (will try the next handler in the resolver chain)
         return None
     except Exception as ex:
-        logger.warn('Cannot resolve iTunes feed: {}'.format(str(ex)))
+        logger.warn(f'Cannot resolve iTunes feed: {str(ex)}')
         raise
 
 @registry.directory.register_instance
@@ -69,6 +69,6 @@ class ApplePodcastsSearchProvider(directory.Provider):
         self.priority = directory.Provider.PRIORITY_SECONDARY_SEARCH
 
     def on_search(self, query):
-        json_url = 'https://itunes.apple.com/search?media=podcast&term={}'.format(urllib.parse.quote(query))
+        json_url = f'https://itunes.apple.com/search?media=podcast&term={urllib.parse.quote(query)}'
 
         return [directory.DirectoryEntry(entry['collectionName'], entry['feedUrl'], entry['artworkUrl100']) for entry in util.read_json(json_url)['results']]

--- a/src/gpodder/plugins/itunes.py
+++ b/src/gpodder/plugins/itunes.py
@@ -95,9 +95,11 @@ class ApplePodcastsSearchProvider(directory.Provider):
             )
             json_data = util.read_json(json_url)
 
+            # Due to the iTunes API not behaving like documented the stop
+            # condition is no further results returned.
             if json_data['resultCount'] <= 0:
                 return
-                
+
             for entry in json_data['results']:
                 if 'feedUrl' not in entry:
                     continue

--- a/src/gpodder/plugins/itunes.py
+++ b/src/gpodder/plugins/itunes.py
@@ -1,6 +1,7 @@
 #
 # gpodder.plugins.itunes: Resolve iTunes feed URLs (based on a gist by Yepoleb, 2014-03-09)
-# Copyright (c) 2014-2025, Thomas Perl <m@thp.io>. E.S. Rosenberg (keeper-of-the-keys)
+# Copyright (c) 2014, Thomas Perl <m@thp.io>.
+# Copyright (c) 2025, E.S. Rosenberg (Keeper-of-the-Keys).
 #
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above
@@ -46,7 +47,7 @@ def itunes_feed_handler(channel, max_episodes, config):
         json_data = util.read_json(itunes_lookup_url)
 
         if len(json_data['results']) != 1:
-            raise ITunesFeedException(f'Unsupported number of results: {str(len(json_data["results"]))}')
+            raise ITunesFeedException(f'Unsupported number of results: {len(json_data["results"])}')
 
         feed_url = util.normalize_feed_url(json_data['results'][0]['feedUrl'])
 
@@ -60,7 +61,7 @@ def itunes_feed_handler(channel, max_episodes, config):
         # by returning None (will try the next handler in the resolver chain)
         return None
     except Exception as ex:
-        logger.warn(f'Cannot resolve iTunes feed: {str(ex)}')
+        logger.warn(f'Cannot resolve iTunes feed: {ex}')
         raise
 
 @registry.directory.register_instance
@@ -86,10 +87,10 @@ class ApplePodcastsSearchProvider(directory.Provider):
                     url = entry['feedUrl']
                     image = entry['artworkUrl100']
 
-                    yield(directory.DirectoryEntry(title, url, image))
+                    yield directory.DirectoryEntry(title, url, image)
                     returned_res += 1
 
-                offset = offset + json_data['resultCount']
+                offset += json_data['resultCount']
             else:
             '''
             Unlike the podverse stop condition where we detect a resultCount smaller than the page size for apple we can only stop when 0 results


### PR DESCRIPTION
- Ignore podcasts that are returned without a `feedUrl` (resolves https://github.com/gpodder/gpodder-sailfish/issues/225)
- Add pagination support so big result sets can be read